### PR TITLE
update regex to avoid incorrect match

### DIFF
--- a/demo/js/functions.js
+++ b/demo/js/functions.js
@@ -242,7 +242,7 @@ function getSelectorCss(selector, stylesheet) {
                 if (mySelector.match(/,/)) {  //if mySelector has commas:
                      mySelectorArray = mySelector.split(',');  //split into array where commas separate items
                      mySelectorArray.forEach(function(itemP, indexP) {  //cycle through the array
-                         regexSelector = new RegExp(selector + '.*');
+                         regexSelector = new RegExp(selector + '(?:$|[^0-9]+)');
                          finalSelector = itemP.match(regexSelector);
                          if (finalSelector !== null) {
                              selectorLoopResult = finalSelector[0];


### PR DESCRIPTION
with the original regex, it will match some incorrect classes. For example, if the itemP is `".abc"`, then `".abc2"` will also be considered as a match.
This bug will cause the incorrect CSS text in demo. For example, if you click on `<a href="#" class="hbtn hb-fill-middle">Slide Middle</a>`, it will show CSS text for class `".hb-fill-middle2:hover"`